### PR TITLE
[FEATURE] product-service 재고 복구 API 추가

### DIFF
--- a/services/product-service/app/main.py
+++ b/services/product-service/app/main.py
@@ -2,6 +2,14 @@
 product-service FastAPI 애플리케이션 진입점
 """
 
+import os
+import sys
+
+BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+sys.path.append(BASE_DIR)
+
 from contextlib import asynccontextmanager
 
 import structlog

--- a/services/product-service/app/routes/products.py
+++ b/services/product-service/app/routes/products.py
@@ -21,6 +21,8 @@ from ..schemas import (
     ProductUpdate,
     StockDeductRequest,
     StockDeductResponse,
+    StockRestoreRequest,
+    StockRestoreResponse,
 )
 
 router = APIRouter(prefix="/products", tags=["products"])
@@ -387,6 +389,70 @@ async def deduct_stock(
     )
 
     return StockDeductResponse(
+        product_id=product_id,
+        remaining_stock=row.stock,
+        new_version=row.version,
+    )
+
+
+@router.post(
+    "/{product_id}/restore-stock",
+    response_model=StockRestoreResponse,
+    responses={
+        404: {"model": ErrorResponse},
+    },
+)
+async def restore_stock(
+    product_id: int,
+    payload: StockRestoreRequest,
+    db: DBSession,
+    _: None = Depends(verify_internal_service),
+):
+    """
+    재고 복구 (order-service 보상 트랜잭션 전용 내부 API).
+
+    낙관적 잠금 미적용:
+    - 보상 트랜잭션은 "이미 차감된 수량을 되돌리는" 단방향 연산
+    - 경합이 발생할 수 없으므로 version 체크 불필요
+    - version 충돌로 복구가 막히면 재고가 영구 소실되는 더 큰 장애 발생
+
+    stock += quantity 원자적 증가.
+    """
+    stmt = (
+        update(Product)
+        .where(
+            Product.id == product_id,
+            Product.is_active.is_(True),
+        )
+        .values(
+            stock=Product.stock + payload.quantity,
+            version=Product.version + 1,  # version은 증가 (변경 이력 추적용)
+        )
+        .returning(Product.stock, Product.version)
+    )
+
+    result = await db.execute(stmt)
+    row = result.fetchone()
+    await db.commit()
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="상품을 찾을 수 없습니다.",
+        )
+
+    # 재고 복구 후 캐시 무효화
+    await invalidate_product_cache(redis_client, product_id)
+
+    log.info(
+        "재고 복구 완료 (보상 트랜잭션)",
+        product_id=product_id,
+        quantity=payload.quantity,
+        remaining_stock=row.stock,
+        new_version=row.version,
+    )
+
+    return StockRestoreResponse(
         product_id=product_id,
         remaining_stock=row.stock,
         new_version=row.version,

--- a/services/product-service/app/schemas.py
+++ b/services/product-service/app/schemas.py
@@ -70,6 +70,26 @@ class StockDeductResponse(BaseModel):
     new_version: int
 
 
+class StockRestoreRequest(BaseModel):
+    """
+    재고 복구 요청 (order-service 보상 트랜잭션 전용).
+
+    낙관적 잠금 미적용 이유:
+    - 복구는 이미 차감된 수량을 되돌리는 것 → 다른 요청과 경합 없음
+    - version 충돌로 복구가 실패하면 보상 트랜잭션 자체가 무효화되는 더 큰 문제 발생
+    """
+
+    quantity: int = Field(..., gt=0, description="복구할 수량 (1 이상)")
+
+
+class StockRestoreResponse(BaseModel):
+    """재고 복구 성공 응답."""
+
+    product_id: int
+    remaining_stock: int
+    new_version: int
+
+
 class ErrorResponse(BaseModel):
     """에러 응답 표준 형식."""
 


### PR DESCRIPTION
### PR 타입

FEATURE : 새로운 기능 추가

### 반영 브랜치

feat/#21 -> main

### 변경 사항

#21

### 테스트 결과
```
2026-05-04T08:08:07.224355Z [info     ] 요청 수신                          client_ip=127.0.0.1 method=POST path=/products/8/restore-stock
2026-05-04 17:08:07,228 INFO sqlalchemy.engine.Engine BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
2026-05-04 17:08:07,228 INFO sqlalchemy.engine.Engine UPDATE products SET stock=(products.stock + $1::INTEGER), version=(products.version + $2::INTEGER), updated_at=now() WHERE products.id = $3::BIGINT AND products.is_active IS true RETURNING products.stock, products.version
INFO:sqlalchemy.engine.Engine:UPDATE products SET stock=(products.stock + $1::INTEGER), version=(products.version + $2::INTEGER), updated_at=now() WHERE products.id = $3::BIGINT AND products.is_active IS true RETURNING products.stock, products.version
2026-05-04 17:08:07,229 INFO sqlalchemy.engine.Engine [cached since 28.89s ago] (1, 1, 8)
INFO:sqlalchemy.engine.Engine:[cached since 28.89s ago] (1, 1, 8)
2026-05-04 17:08:07,230 INFO sqlalchemy.engine.Engine COMMIT
INFO:sqlalchemy.engine.Engine:COMMIT
2026-05-04T08:08:07.264596Z [info     ] 재고 복구 완료 (보상 트랜잭션)             new_version=3 product_id=8 quantity=1 remaining_stock=7
2026-05-04T08:08:07.264596Z [info     ] 요청 완료                          duration_ms=40.94 method=POST path=/products/8/restore-stock status_code=200
INFO:     127.0.0.1:6263 - "POST /products/8/restore-stock HTTP/1.1" 200 OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상품 재고 복구 기능 추가: 상품 재고를 정확하게 관리하고, 필요시 신속하게 복구할 수 있습니다. 자동 데이터 동기화로 최신 정보를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->